### PR TITLE
Use UTF-8 encoding to read the README file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ def project_content(filename):
     if not os.path.isfile(filepath):
         raise IOError("""File %s doesn't exist""" % filepath)
     out = ''
-    with io.open(filepath, 'r') as handle:
+    with io.open(filepath, 'r', encoding='utf-8') as handle:
         out += handle.read()
     if not out:
         raise ValueError("""File %s couldn't be read""" % filename)


### PR DESCRIPTION
I had trouble installing this package on a system that uses a locale without Unicode:

```console
me@home:~$ python3 setup.py
Traceback (most recent call last):
  File "setup.py", line 93, in <module>
    LONG_DESCRIPTION = project_content('README.md')
  File "setup.py", line 77, in project_content
    out += handle.read()
  File "/usr/lib/python3.5/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 99: ordinal not in range(128)
```

Explicitly setting the `encoding` to 'utf-8' in the call to `open()` fixes this problem.